### PR TITLE
nodeport yaml provided and readme updated for faster up-and-running option

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,16 @@ kubectl apply -f https://raw.githubusercontent.com/herbrandson/k8dash/master/kub
 
 ```
 
+## Running k8dash with NodePort
+If you do not have an ingress server setup, you can utilize a NodePort service as configured in the [kubernetes-k8dash-nodeport.yaml](https://raw.githubusercontent.com/herbrandson/k8dash/master/kubernetes-k8dash-nodeport.yaml). This is ideal when creating a single node master, or if you want to get up and running as fast as possible.
 
+This will map the k8dash port 4654 to a randomly selected port on the running node. The assigned port can be found using
+```
+$ kubectl get svc --namespace=kube-system
+
+NAME       TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
+k8dash     NodePort    10.107.107.62   <none>        4654:32565/TCP   1m
+```
 
 ## Metrics
 K8dash relies heavily on [metrics-server](https://github.com/kubernetes-incubator/metrics-server) to display real time cluster metrics. It is strongly recommended to have metrics-server installed to get the best experiance from k8dash.

--- a/kubernetes-k8dash-nodeport.yaml
+++ b/kubernetes-k8dash-nodeport.yaml
@@ -1,0 +1,40 @@
+kind: Deployment
+apiVersion: apps/v1beta2
+metadata:
+  name: k8dash
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: k8dash
+  template:
+    metadata:
+      labels:
+        k8s-app: k8dash
+    spec:
+      containers:
+      - name: k8dash
+        image: herbrandson/k8dash:latest
+        ports:
+        - containerPort: 4654
+        livenessProbe:
+          httpGet:
+            scheme: HTTP
+            path: /
+            port: 4654
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: k8dash
+  namespace: kube-system
+spec:
+  type: NodePort
+  ports:
+    - port: 4654
+  selector:
+    k8s-app: k8dash


### PR DESCRIPTION
For individuals running docker-for-desktop or local single-node clusters, running and ingress is potentially an extra step. This makes it even easier to get k8dash up and running.