### PR TITLE
Fix parsing disk space / ram

### DIFF
--- a/client/src/utils/unitHelpers.js
+++ b/client/src/utils/unitHelpers.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 
 const RAM_TYPES = ['Bi', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei'];
+const UNITS = ['B', 'K', 'M', 'G', 'T', 'P', 'E'];
 
 export const TO_GB = 1024 * 1024 * 1024;
 export const TO_ONE_M_CPU = 1000000;
@@ -9,29 +10,55 @@ export const TO_ONE_CPU = 1000000000;
 export function parseDiskSpace(value) {
     if (!value) return 0;
 
-    const number = parseInt(value, 10);
-    if (value.endsWith('Ki')) return number * 1024;
-    if (value.endsWith('Mi')) return number * 1024 * 1024;
-    if (value.endsWith('Gi')) return number * 1024 * 1024 * 1024;
-    if (value.endsWith('Ti')) return number * 1024 * 1024 * 1024 * 1024;
-    if (value.endsWith('Pi')) return number * 1024 * 1024 * 1024 * 1024 * 1024;
-    if (value.endsWith('Ei')) return number * 1024 * 1024 * 1024 * 1024 * 1024 * 1024;
+    const groups = value.match(/(\d+)([BKMGTPEe])?(i)?(\d+)?/);
+    const number = parseInt(groups[1], 10);
 
-    return number;
+    // number ex. 1000
+    if (groups[2] === undefined) {
+        return number;
+    }
+
+    // number with exponent ex. 1e3
+    if (groups[4] !== undefined) {
+        return number * (10 ** parseInt(groups[4], 10));
+    }
+
+    const unitIndex = _.indexOf(UNITS, groups[2]);
+
+    // Unit + i ex. 1Ki
+    if (groups[3] !== undefined) {
+        return number * (1024 ** unitIndex);
+    }
+
+    // Unit ex. 1K
+    return number * (1000 ** unitIndex);
 }
 
 export function parseRam(value) {
     if (!value) return 0;
 
-    const number = parseInt(value, 10);
-    if (value.endsWith('Ki')) return number * 1024;
-    if (value.endsWith('Mi')) return number * 1024 * 1024;
-    if (value.endsWith('Gi')) return number * 1024 * 1024 * 1024;
-    if (value.endsWith('Ti')) return number * 1024 * 1024 * 1024 * 1024;
-    if (value.endsWith('Pi')) return number * 1024 * 1024 * 1024 * 1024 * 1024;
-    if (value.endsWith('Ei')) return number * 1024 * 1024 * 1024 * 1024 * 1024 * 1024;
+    const groups = value.match(/(\d+)([BKMGTPEe])?(i)?(\d+)?/);
+    const number = parseInt(groups[1], 10);
 
-    return number;
+    // number ex. 1000
+    if (groups[2] === undefined) {
+        return number;
+    }
+
+    // number with exponent ex. 1e3
+    if (groups[4] !== undefined) {
+        return number * (10 ** parseInt(groups[4], 10));
+    }
+
+    const unitIndex = _.indexOf(UNITS, groups[2]);
+
+    // Unit + i ex. 1Ki
+    if (groups[3] !== undefined) {
+        return number * (1024 ** unitIndex);
+    }
+
+    // Unit ex. 1K
+    return number * (1000 ** unitIndex);
 }
 
 export function unparseRam(value) {

--- a/client/src/utils/unitHelpers.js
+++ b/client/src/utils/unitHelpers.js
@@ -8,33 +8,14 @@ export const TO_ONE_M_CPU = 1000000;
 export const TO_ONE_CPU = 1000000000;
 
 export function parseDiskSpace(value) {
-    if (!value) return 0;
-
-    const groups = value.match(/(\d+)([BKMGTPEe])?(i)?(\d+)?/);
-    const number = parseInt(groups[1], 10);
-
-    // number ex. 1000
-    if (groups[2] === undefined) {
-        return number;
-    }
-
-    // number with exponent ex. 1e3
-    if (groups[4] !== undefined) {
-        return number * (10 ** parseInt(groups[4], 10));
-    }
-
-    const unitIndex = _.indexOf(UNITS, groups[2]);
-
-    // Unit + i ex. 1Ki
-    if (groups[3] !== undefined) {
-        return number * (1024 ** unitIndex);
-    }
-
-    // Unit ex. 1K
-    return number * (1000 ** unitIndex);
+    return parseUnitsOfBytes(value);
 }
 
 export function parseRam(value) {
+    return parseUnitsOfBytes(value);
+} 
+    
+function parseUnitsOfBytes(value) {
     if (!value) return 0;
 
     const groups = value.match(/(\d+)([BKMGTPEe])?(i)?(\d+)?/);


### PR DESCRIPTION
As stated in original doc resources can be defined in 4 ways:

128974848, 129e6, 129M, 123Mi

Only the first and last one option was supported. When resource limits/reqs were defined like 80M I got funny results like that:

![image](https://user-images.githubusercontent.com/13802274/55686592-6608d500-5963-11e9-8700-d94c8fc34503.png)

Ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory
