### PR TITLE
Better handling of missing requests for cpu/mem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 TODO
 **/node_modules
 **/build
+.vscode

--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -9,7 +9,8 @@
     "parserOptions": {
         "jsx": true
     },
-    "rules": {
+    "rules": {        
+        "max-len": ["error", 150],
         "indent": [
             "error",
             4,

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3988,6 +3988,31 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-env": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.5",
+        "is-windows": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,7 @@
     "yamljs": "^0.3.0"
   },
   "scripts": {
-    "start": "PORT=4653 react-scripts start",
+    "start": "cross-env PORT=4653 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
@@ -40,6 +40,7 @@
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-jsx-a11y": "^6.2.1",
-    "eslint-plugin-react": "^7.12.4"
+    "eslint-plugin-react": "^7.12.4",
+    "cross-env": "^5.2.0"
   }
 }

--- a/client/src/components/chart.js
+++ b/client/src/components/chart.js
@@ -11,7 +11,7 @@ const options = {
 };
 
 export default function Chart(props) {
-    const {used = 0, usedSuffix, available = 0, availableSuffix, pending = 0, decimals = 1} = props;
+    const {used = 0, usedSuffix, available = 0, availableSuffix, pending = 0, decimals = 1, defined = true} = props;
 
     const fixedUsed = _.round(used, decimals);
     const fixedPending = _.round(pending, decimals);
@@ -31,15 +31,15 @@ export default function Chart(props) {
                         </>
                     )}
                 </div>
-                <div className='chart_innerLabel'>of</div>
-                <div>
+                {defined && <div className='chart_innerLabel'>of</div>}
+                {defined && <div>
                     {Number.isFinite(fixedAvailable) && (
                         <>
                             <span>{fixedAvailable}</span>
                             {availableSuffix && (<span className='chart_innerLabel'>{availableSuffix}</span>)}
                         </>
                     )}
-                </div>
+                </div>}
             </span>
         </div>
     );

--- a/client/src/components/cpuChart.js
+++ b/client/src/components/cpuChart.js
@@ -22,7 +22,8 @@ export default function CpuChart({items, metrics}) {
             ) : (
                 <LoadingChart />
             )}
-            <div className='charts_itemLabel'>Cores Used</div>
+            <div className='charts_itemLabel'>Pod Cpu Use</div>
+            <div className='charts_itemSubLabel'>Actual vs Reserved</div>
         </div>
     );
 }

--- a/client/src/components/podsPanel.js
+++ b/client/src/components/podsPanel.js
@@ -5,6 +5,7 @@ import Base from './base';
 import {MetadataHeaders, MetadataColumns, TableBody} from './listViewHelpers';
 import Sorter from './sorter';
 import {parseRam, unparseRam, parseCpu, unparseCpu} from '../utils/unitHelpers';
+import {getCpuRequestFlag, getRamRequestFlag} from '../utils/itemHelpers';
 
 export default class PodsPanel extends Base {
     constructor(props) {
@@ -117,10 +118,6 @@ function getCpuRequest(item, metrics) {
     });
 }
 
-function getCpuRequestFlag(item) {
-    return !_.some(item.spec.containers, x => !x.resources.requests || !x.resources.requests.cpu);
-}
-
 function Ram({item, metrics}) {
     const containers = getContainerMetrics(item, metrics);
     if (!containers) return null;
@@ -164,10 +161,6 @@ function getRamRequest(item, metrics) {
         if (!x.resources.requests || !x.resources.requests.memory) return getRamUsage(item, metrics, x.name);
         return parseRam(x.resources.requests.memory);
     });
-}
-
-function getRamRequestFlag(item) {
-    return !_.some(item.spec.containers, x => !x.resources.requests || !x.resources.requests.memory);
 }
 
 function getContainerMetrics(item, metrics) {

--- a/client/src/components/ramChart.js
+++ b/client/src/components/ramChart.js
@@ -24,7 +24,8 @@ export default function RamChart({items, metrics}) {
             ) : (
                 <LoadingChart />
             )}
-            <div className='charts_itemLabel'>Ram Used</div>
+            <div className='charts_itemLabel'>Pod Ram Use</div>
+            <div className='charts_itemSubLabel'>Actual vs Reserved</div>
         </div>
     );
 }

--- a/client/src/components/ramChart.js
+++ b/client/src/components/ramChart.js
@@ -3,10 +3,12 @@ import React from 'react';
 import Chart from './chart';
 import LoadingChart from './loadingChart';
 import {parseRam, TO_GB} from '../utils/unitHelpers';
+import {getRamRequestFlag} from '../utils/itemHelpers';
 
 export default function RamChart({items, metrics}) {
     const totals = getPodRamTotals(items, metrics);
     const decimals = totals && totals.used > 10 ? 1 : 2;
+    const defined = items ? !_(items).every(x => !getRamRequestFlag(x)) : true;
 
     return (
         <div className='charts_item'>
@@ -17,6 +19,7 @@ export default function RamChart({items, metrics}) {
                     usedSuffix='Gb'
                     available={totals && totals.available}
                     availableSuffix='Gb'
+                    defined={defined}
                 />
             ) : (
                 <LoadingChart />

--- a/client/src/utils/itemHelpers.js
+++ b/client/src/utils/itemHelpers.js
@@ -1,0 +1,9 @@
+import _ from 'lodash';
+
+export function getCpuRequestFlag(item) {
+    return !_.every(item.spec.containers, x => !x.resources.requests || !x.resources.requests.cpu);
+}
+
+export function getRamRequestFlag(item) {
+    return !_.every(item.spec.containers, x => !x.resources.requests || !x.resources.requests.memory);
+}


### PR DESCRIPTION
I've included a small fix for Windows using ``cross-env``. Basically it's not possible set ENV like that on this OS. It has to be ``SET PORT``. ``cross-env`` is widely used for maintaining a compatibility across platforms. So I hope it's ok with you.

During implementation for #13 issue I changed my mind a little bit. Removing ``X %`` turned out to be quite distractions so I keep it as 100% and instead removed ``of X[unit]`` part. It looks quite cool 😎

I didn't know that this scenario applies only to the situation when you do not set limits as well. If you set limits and no requests, limits are being automatically used as requests.

Moreover there's a small problem when you have more containers with "mixed" requests (set / missing). 
Only when all the containers have not set requests I'm activating this special display mode.

![image](https://user-images.githubusercontent.com/13802274/56092407-0f981b00-5ebc-11e9-8e79-e8d7a110e61d.png)

And I modified charts as well.

![image](https://user-images.githubusercontent.com/13802274/56092329-28540100-5ebb-11e9-9af1-44fb2520f44b.png)