### PR TITLE
ensure k8dash scheduled on linux nodes

### DIFF
--- a/kubernetes-k8dash-nodeport.yaml
+++ b/kubernetes-k8dash-nodeport.yaml
@@ -25,6 +25,8 @@ spec:
             port: 4654
           initialDelaySeconds: 30
           timeoutSeconds: 30
+      nodeSelector:
+        'beta.kubernetes.io/os': linux
 
 ---
 kind: Service

--- a/kubernetes-k8dash-oidc.yaml
+++ b/kubernetes-k8dash-oidc.yaml
@@ -41,6 +41,8 @@ spec:
             secretKeyRef:
               name: k8dash
               key: secret
+      nodeSelector:
+        'beta.kubernetes.io/os': linux
 
 ---
 kind: Service

--- a/kubernetes-k8dash.yaml
+++ b/kubernetes-k8dash.yaml
@@ -25,6 +25,8 @@ spec:
             port: 4654
           initialDelaySeconds: 30
           timeoutSeconds: 30
+      nodeSelector:
+        'beta.kubernetes.io/os': linux
 
 ---
 kind: Service


### PR DESCRIPTION
Ensures that k8dash is not scheduled on a windows node.

This addresses issue https://github.com/herbrandson/k8dash/issues/23