### PR TITLE
Use humanize-duration to better format duration (mo, m, ms)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
   "homepage": ".",
   "dependencies": {
     "ansi-to-react": "^5.0.0",
+    "humanize-duration": "3.21.0",
     "js-base64": "^2.5.1",
     "js-cookie": "^2.2.0",
     "lodash": "^4.17.11",
@@ -17,7 +18,6 @@
     "react-swipeable": "^5.2.3",
     "react-switch": "^5.0.0",
     "swagger-parser": "^7.0.0",
-    "time-ago": "^0.2.1",
     "xterm": "^3.14.2",
     "yamljs": "^0.3.0"
   },

--- a/client/src/utils/dates.js
+++ b/client/src/utils/dates.js
@@ -1,5 +1,31 @@
-import timeAgo from 'time-ago';
+import HumanizeDuration from 'humanize-duration'
 
-export default function fromNow(value) {
-    return timeAgo.ago(value, true);
+/**
+ * A simple humanizer to merely differentiate between months and minutes.
+ * (Could be improved later for i18n)
+ */
+const shortEnglishHumanizer = HumanizeDuration.humanizer({
+    language: 'shortEn',
+    languages: {
+      shortEn: {
+        y: () => 'y',
+        mo: () => 'mo',
+        w: () => 'w',
+        d: () => 'd',
+        h: () => 'h',
+        m: () => 'm',
+        s: () => 's',
+        ms: () => 'ms',
+      }
+    }
+  })
+
+ /**
+  * @param epochtimestampMs an epoch timestamp value (in ms)
+  * @returns a "humanized" duration from now
+  * 
+  */ 
+export default function fromNow(epochtimestampMs) {
+    var diff = Date.now() - new Date(epochtimestampMs).getTime()
+    return shortEnglishHumanizer(diff).split(",")[0]
 }


### PR DESCRIPTION
`time-ago` is replaced with `humanize-duration` to better format duration