### PR TITLE
#47: Treat token as password field

### DIFF
--- a/client/src/views/auth.js
+++ b/client/src/views/auth.js
@@ -46,7 +46,9 @@ export default class Auth extends Base {
                         <LogoSvg className='optional_small' />
                         <input
                             type='password'
+                            name='password'
                             className='auth_input'
+                            autoComplete='current-password'
                             placeholder='Enter your auth token here...'
                             spellCheck='false'
                             value={token}


### PR DESCRIPTION
Fixes #47 by setting the autoComplete (jsx style) attribute to current password and the name as password to allow password managers to fill the token (e.g. manage the token for the user)