### PR TITLE
fix deprecated api versions

### DIFF
--- a/kubernetes-k8dash-nodeport.yaml
+++ b/kubernetes-k8dash-nodeport.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: k8dash
   namespace: kube-system

--- a/kubernetes-k8dash-oidc.yaml
+++ b/kubernetes-k8dash-oidc.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: k8dash
   namespace: kube-system

--- a/kubernetes-k8dash.yaml
+++ b/kubernetes-k8dash.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: k8dash
   namespace: kube-system


### PR DESCRIPTION
As of at least 1.16, the `apps/v1beta2` apVersion will no longer work with deployments.  We should be using `apps/v1`